### PR TITLE
Find free port if 3123 is in use

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,9 @@ var fs = require('fs');
 var _ = require('lodash');
 var RSVP = require('rsvp');
 var readFile = RSVP.denodeify(fs.readFile);
+var findPort = RSVP.denodeify(require('find-port'));
 var has = require('./lib/has');
+
 
 function hashStr(str) {
   var hasher = crypto.createHash('sha256');
@@ -129,7 +131,7 @@ module.exports = function(bundle, opts) {
       } else {
         resolve();
       }
-    }).then(function(){
+    }).then(findPort(port)).then(function(port){
       server.send({
         type: 'config',
         hostname: hostname,

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "convert-source-map": "^1.1.1",
     "express": "^4.13.3",
+    "find-port": "^1.0.1",
     "lodash": "^3.10.1",
     "rsvp": "^3.0.21",
     "socket.io": "^1.3.7",


### PR DESCRIPTION
Heya!

I've been making extensive use of this library recently, and it's been super useful.

I've been using it so much that I often find myself wanting to run two instance of budo + browserify-hmr at once. Currently this fails with a port in use error.

I've changed it to use find-port to find the next available port.

The only downside I can think of is if you explicitly specify a port that is in use, it will find the next free port, so it might end up running in a different place than you expect.

I would love to write a test for this but I'm not quite sure how to go about it with coroutines and promises. If you have any thoughts I would love to hear them.