### PR TITLE
Make the default updateUrl compatible with HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ updates and applies them, so the application never gets a chance to call
 
 `u, url` is a string which sets the update URL that the websocket connection or
 Browserify bundle is accessible at. In "websocket" mode, this defaults to
-"http://localhost:3123". This is required for the "ajax" mode. This is not
+"//localhost:3123". This is required for the "ajax" mode. This is not
 required for "fs" mode.
 
 `p, port` is a number that sets the port to listen on if "websocket" mode is

--- a/inc/index.js
+++ b/inc/index.js
@@ -405,7 +405,7 @@ function main(
     };
 
     var setupSocket = function() {
-      var url = updateUrl || 'http://localhost:3123';
+      var url = updateUrl || '//localhost:3123';
       var socket = socketio(url, {'force new connection': true});
       console.log('[HMR] Attempting websocket connection to', url);
 


### PR DESCRIPTION
The default updateUrl (http://localhost:3123) is blocked by Chrome when testing my site using HTTPS and using the `-K key.pem -C cert.pem` options.

![image](https://cloud.githubusercontent.com/assets/587740/23917147/ca18b4da-08c4-11e7-8284-7919a5fb63e5.png)

The websocket connection does work if I specify `-u https://localhost:3123` explicitly. However, I don't think I'm unique in preferring the default settings to work out-of-the-box! So I fixed this the simplest way I could: by making the default updateUrl `//localhost:3123` instead of `http://localhost:3123`. This tells the browser to use whichever protocol (HTTP or HTTPS) was used to load the webpage itself.

I updated the README and can say it works on my machine. (I was unable to run the tests on Windows.)