### PR TITLE
Use latest socket.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "express": "^4.13.3",
     "lodash": "^4.0.0",
     "rsvp": "^3.0.21",
-    "socket.io": "^1.3.7",
-    "socket.io-client": "^1.3.7",
+    "socket.io": "^2.0.4",
+    "socket.io-client": "^2.0.4",
     "source-map": "^0.5.1",
     "synchd": "^1.0.0",
     "through2": "^2.0.0"


### PR DESCRIPTION
I have been using browserify-hmr in few projects and facing issue with `parsejson` dependency with usage of `yarn` due to outdated `socket.io-client / engine.io-client` version.

`parsejson` dependency is removed from latest engine.io-client which is resolved by my host project dependency and browserify complains about not able to locate `parsejson`.